### PR TITLE
fix: unpin pybind11 patch version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "pybind11~=2.6.1"]
+requires = ["setuptools>=42", "wheel", "pybind11~=2.6"]
 build-backend = "setuptools.build_meta"
-


### PR DESCRIPTION
This fix allows more recent minor versions of `pybind11` to be used, which in particular allows using this library for Python versions `>= 3.11`. The `pybind11` release which added this support was https://github.com/pybind/pybind11/releases/tag/v2.10.1.

By removing the patch version from the `~=`, it allows any compatible minor versions to be installed, which means any version `>=2.6, <3` ([ref](https://packaging.python.org/en/latest/specifications/version-specifiers/#compatible-release)). Tested this locally, but if you have a more comprehensive battery of tests, I'm happy to try running those as well!