### PR TITLE
Standardize CIF files before analyzing them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "pybind11~=2.6"]
+requires = ["setuptools>=42", "wheel", "pybind11~=2.6", "manage_crystal"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 click
+manage_crystal

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ packages = find_namespace:
 install_requires=
     pybind11
     click
+    manage_crystal
 python_requires = >=3.7
 package_dir =
     =src

--- a/src/pyeqeq/main.py
+++ b/src/pyeqeq/main.py
@@ -3,7 +3,10 @@ import io
 import json
 import pathlib
 from contextlib import ExitStack, redirect_stderr
+import tempfile
 from typing import Union
+
+from manage_crystal.utils import parse_and_write
 
 import pyeqeq_eqeq
 
@@ -29,18 +32,24 @@ def run_on_cif(
     method = method.lower()
 
     # ExitStack allows conditional context manager
-    with ExitStack() as stack:
+    with tempfile.TemporaryFile() as temp_filename, ExitStack() as stack:
         if not verbose:
             # Capture stderr. It is currently discarded (but could be returned)
             _stderr = io.StringIO()
             stack.enter_context(redirect_stderr(_stderr))
+
+        # Standardize CIF file
+        # Many valid CIF files will not be correctly read by EQeq, since that assumes a particular ordering of the
+        # atom properties, see https://github.com/lsmo-epfl/EQeq/issues/24
+        # We use the manage_crystals library to bring any input CIF file into the format expected by EQeq
+        parse_and_write(cif, temp_filename)
 
         # Redirect C++ std::cout and std::cerr to python sys.stdout and sys.stderr
         # This needs to happen *before* capturing stdout/stderr at the python
         with pyeqeq_eqeq.ostream_redirect(stdout=True, stderr=True):
 
             result = pyeqeq_eqeq.run(
-                cif,
+                temp_filename,
                 "json" if output_type == "list" else output_type,
                 dielectric_screening,
                 h_electron_affinity,

--- a/src/pyeqeq/main.py
+++ b/src/pyeqeq/main.py
@@ -32,7 +32,7 @@ def run_on_cif(
     method = method.lower()
 
     # ExitStack allows conditional context manager
-    with tempfile.TemporaryFile() as temp_filename, ExitStack() as stack:
+    with tempfile.TemporaryDirectory() as temp_dir, ExitStack() as stack:
         if not verbose:
             # Capture stderr. It is currently discarded (but could be returned)
             _stderr = io.StringIO()
@@ -42,6 +42,9 @@ def run_on_cif(
         # Many valid CIF files will not be correctly read by EQeq, since that assumes a particular ordering of the
         # atom properties, see https://github.com/lsmo-epfl/EQeq/issues/24
         # We use the manage_crystals library to bring any input CIF file into the format expected by EQeq
+        if verbose:
+            print("Standardizing CIF file")
+        temp_filename = str(pathlib.Path(temp_dir) / "standardized.cif")
         parse_and_write(cif, temp_filename)
 
         # Redirect C++ std::cout and std::cerr to python sys.stdout and sys.stderr


### PR DESCRIPTION
Fixes #24 by standardizing CIF files with the manage_crystal library before the charge computing.